### PR TITLE
Upgrade Packages & Multitarget Project

### DIFF
--- a/ScheduleWidget/ScheduleWidget.Sandbox/ScheduleWidget.Sandbox.csproj
+++ b/ScheduleWidget/ScheduleWidget.Sandbox/ScheduleWidget.Sandbox.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="BuildBundlerMinifier" Version="2.8.391" />
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.6" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.2.3" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.2.3" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
   </ItemGroup>
 

--- a/ScheduleWidget/ScheduleWidget.UnitTests/ScheduleWidget.UnitTests.csproj
+++ b/ScheduleWidget/ScheduleWidget.UnitTests/ScheduleWidget.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
   </ItemGroup>

--- a/ScheduleWidget/ScheduleWidget/ScheduleWidget.csproj
+++ b/ScheduleWidget/ScheduleWidget/ScheduleWidget.csproj
@@ -9,13 +9,13 @@
     <Copyright>Copyright (c) 2017 James Still</Copyright>
     <PackageTags>schedule recurring events calendar calendars</PackageTags>
     <PackageProjectUrl>http://schedulewidget.azurewebsites.net</PackageProjectUrl>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-    <Version>2.1.1</Version>
+    <TargetFrameworks>netstandard2.0;net45;net46;net47;</TargetFrameworks>
+    <Version>2.1.2</Version>
     <PackageReleaseNotes></PackageReleaseNotes>
     <RepositoryUrl>https://github.com/jamesstill/ScheduleWidget.Core</RepositoryUrl>
     <PackageIconUrl>https://squarewidget.com/wp-content/uploads/2018/10/sw_logo_171_x_179.png</PackageIconUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>2.1.1.0</AssemblyVersion>
-    <FileVersion>2.1.1.0</FileVersion>
+    <AssemblyVersion>2.1.2.0</AssemblyVersion>
+    <FileVersion>2.1.2.0</FileVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Target netstandard2.0 instead of .NetCoreApp
Multitargetting .NET 4.5 .NET 4.6 & .NET 4.7